### PR TITLE
Added productionTime to InvBlueprintType

### DIFF
--- a/eve_db/ccp_importer/importers/inventory.py
+++ b/eve_db/ccp_importer/importers/inventory.py
@@ -177,6 +177,7 @@ class Importer_invBlueprintTypes(SQLImporter):
     model = InvBlueprintType
     pks = (('blueprint_type', 'blueprintTypeID'),)
     field_map = (('product_type_id', 'productTypeID'),
+                 ('production_time', 'productionTime'),
                  ('parent_blueprint_type_id', 'parentBlueprintTypeID'),
                  ('tech_level', 'techLevel'),
                  ('research_productivity_time', 'researchProductivityTime'),

--- a/eve_db/models/inventory.py
+++ b/eve_db/models/inventory.py
@@ -373,6 +373,7 @@ class InvBlueprintType(models.Model):
     parent_blueprint_type = models.ForeignKey(InvType, blank=True,
                                               null=True,
                                               related_name='parent_blueprint_type_set')
+    production_time = models.IntegerField(blank=True, null=True)
     tech_level = models.IntegerField(blank=True, null=True)
     research_productivity_time = models.IntegerField(blank=True, null=True)
     research_material_time = models.IntegerField(blank=True, null=True)


### PR DESCRIPTION
Added productionTime to InvBlueprintType.

I created a test project on my local machine and imported the dump. Importing worked without fault.
- `mkvirtualenv evedbtest`
- `pip install django`
- `pip install pip install git+https://github.com/jenslauterbach/django-eve-db.git`
- `django-admin.py startproject evedbtest`
- `cd evedbtest`
- `vim evedbtest/settings.py`
- Update `DATABASES`, set 'ENGINE' to 'django.db.backends.sqlite3' and 'NAME' to 'evedbtest.db'
- Add 'eve_db' to `INSTALLED_APPS`
- Save settings.py
- `python manage.py syncdb`
- `wget https://github.com/downloads/gtaylor/django-eve-db/inferno12.db3.tar.bz2`
- `tar xfv inferno12.db3.tar.bz2`
- `python manage.py eve_import_ccp_dump inferno12.db3`
- `sqlite3 evedbtest.db`
- `.headers on`
- `select * from eve_db_invblueprinttype where blueprint_type_id = 692;`

And voilá :) production time = 12000
