### PR TITLE
Removed duplicate verbose name

### DIFF
--- a/eve_db/models/inventory.py
+++ b/eve_db/models/inventory.py
@@ -673,8 +673,8 @@ class InvUniqueName(models.Model):
     class Meta:
         app_label = 'eve_db'
         ordering = ['id']
-        verbose_name = 'Position'
-        verbose_name_plural = 'Positions'
+        verbose_name = 'Unique Name'
+        verbose_name_plural = 'Unique Names'
 
     def __unicode__(self):
         return self.name


### PR DESCRIPTION
InvPosition and InvUniqueName both had the verbose_name 'Position', updated InvUniqueName to have its own unique verbose_name as well as verbose_name_plural.
